### PR TITLE
Search for python3 instead of python

### DIFF
--- a/versionRules/makeFoamVersionHeader.py
+++ b/versionRules/makeFoamVersionHeader.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # This script processses $WM_PRJECT_VERSION and outputs the result to 
 # foamVersion4wmles.H


### PR DESCRIPTION
On Debian 11 (bullseye) 
`/usr/bin/env python3` is `Python 3.9.2`, but 
`/usr/bin/env python` prints `/usr/bin/env: 'python': No such file or directory`